### PR TITLE
Testdata statistics

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,0 +1,66 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+package rapid
+
+import (
+	"sort"
+)
+
+type counter map[string]int
+type stats map[string]counter
+
+type counterPair struct {
+	frequency int
+	event     string
+}
+
+// TEvent is a minimal interface for recording events and
+// printing statistics.
+type TEvent interface {
+	Helper()
+	Name() string
+	Logf(fmt string, data ...interface{})
+}
+
+// global variable for statistics
+var all_stats stats = make(stats)
+
+// Event records an event for test `t` and
+// stores the event for calculating statistics.
+func Event(t TEvent, event string) {
+	t.Helper()
+	c, found := all_stats[t.Name()]
+	if !found {
+		c = make(counter)
+		all_stats[t.Name()] = c
+	}
+	c[event]++
+}
+
+// PrintStats logs a table of events and their relative frequency.
+// To see these statistics, run the tests with `go test -v`
+func PrintStats(t TEvent) {
+	t.Helper()
+	s, found := all_stats[t.Name()]
+	if !found {
+		t.Logf("No events stored for test %s", t)
+		return
+	}
+	events := make([]counterPair, 0)
+	sum := 0
+	count := 0
+	for ev := range s {
+		sum += s[ev]
+		count++
+		events = append(events, counterPair{event: ev, frequency: s[ev]})
+	}
+	t.Logf("Statistics for %s\n", t.Name())
+	t.Logf("Total of %d different events\n", count)
+	t.Logf(" =====> Sorted by frequency:")
+	sort.Slice(events, func(i, j int) bool { return events[i].frequency > events[j].frequency })
+	for _, ev := range events {
+		t.Logf("%s: %d (%f %%)\n", ev.event, ev.frequency, float32(ev.frequency)/float32(sum)*100.0)
+	}
+}

--- a/event.go
+++ b/event.go
@@ -29,6 +29,10 @@ var all_stats stats = make(stats)
 
 // Event records an event for test `t` and
 // stores the event for calculating statistics.
+//
+// Recording events and printing a their statistic is a tool for
+// analysing test data generations. It helps to understand if
+// your customer generators produce value in the expected range.
 func Event(t TEvent, event string) {
 	t.Helper()
 	c, found := all_stats[t.Name()]

--- a/event.go
+++ b/event.go
@@ -16,14 +16,6 @@ type counterPair struct {
 	event     string
 }
 
-// TEvent is a minimal interface for recording events and
-// printing statistics.
-type TEvent interface {
-	Helper()
-	Name() string
-	Logf(fmt string, data ...interface{})
-}
-
 // global variable for statistics
 var all_stats stats = make(stats)
 
@@ -33,7 +25,7 @@ var all_stats stats = make(stats)
 // Recording events and printing a their statistic is a tool for
 // analysing test data generations. It helps to understand if
 // your customer generators produce value in the expected range.
-func Event(t TEvent, event string) {
+func Event(t TB, event string) {
 	t.Helper()
 	c, found := all_stats[t.Name()]
 	if !found {
@@ -45,7 +37,7 @@ func Event(t TEvent, event string) {
 
 // PrintStats logs a table of events and their relative frequency.
 // To see these statistics, run the tests with `go test -v`
-func PrintStats(t TEvent) {
+func PrintStats(t TB) {
 	t.Helper()
 	s, found := all_stats[t.Name()]
 	if !found {

--- a/event_example_test.go
+++ b/event_example_test.go
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package rapid_test
+
+import (
+	"fmt"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func ExampleEvent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// For any integers x, y ...
+		x := rapid.Int().Draw(t, "x").(int)
+		y := rapid.Int().Draw(t, "y").(int)
+		// ... report them ...
+		rapid.Event(t, fmt.Sprintf("x = %d", x))
+		rapid.Event(t, fmt.Sprintf("y = %d", y))
+
+		// ... the property holds
+		if x+y != y+x {
+			t.Fatalf("associativty of + does not hold")
+		}
+	})
+	// print statistics after the property (if called with go test -v)
+	rapid.PrintStats(t)
+}

--- a/event_test.go
+++ b/event_test.go
@@ -1,4 +1,3 @@
-//
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -24,8 +23,20 @@ func NewTEvent(t *testing.T) *tEvent {
 		output: make([]string, 0),
 	}
 }
-func (t *tEvent) Helper()      { t.t.Helper() }
-func (t *tEvent) Name() string { return t.t.Name() }
+
+// implement rapid.TB trivially except for Logf
+func (t *tEvent) Helper()                                   { t.t.Helper() }
+func (t *tEvent) Name() string                              { return t.t.Name() }
+func (t *tEvent) Error(args ...interface{})                 { t.t.Error(args...) }
+func (t *tEvent) Errorf(format string, args ...interface{}) { t.t.Errorf(format, args...) }
+func (t *tEvent) Fail()                                     { t.t.Fail() }
+func (t *tEvent) FailNow()                                  { t.t.FailNow() }
+func (t *tEvent) Failed() bool                              { return t.t.Failed() }
+func (t *tEvent) Fatal(args ...interface{})                 { t.t.Fatal(args...) }
+func (t *tEvent) Fatalf(format string, args ...interface{}) { t.t.Fatalf(format, args...) }
+func (t *tEvent) SkipNow()                                  { t.t.SkipNow() }
+func (t *tEvent) Skipped() bool                             { return t.t.Skipped() }
+func (t *tEvent) Log(args ...interface{})                   { t.t.Log(args...) }
 func (t *tEvent) Logf(format string, data ...interface{}) {
 	t.t.Logf(format, data...)
 	t.output = append(t.output, fmt.Sprintf(format, data...))

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,54 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package rapid_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	. "pgregory.net/rapid"
+)
+
+type tEvent struct {
+	t      *testing.T
+	output []string
+}
+
+func NewTEvent(t *testing.T) *tEvent {
+	return &tEvent{
+		t:      t,
+		output: make([]string, 0),
+	}
+}
+func (t *tEvent) Helper()      { t.t.Helper() }
+func (t *tEvent) Name() string { return t.t.Name() }
+func (t *tEvent) Logf(format string, data ...interface{}) {
+	t.t.Logf(format, data...)
+	t.output = append(t.output, fmt.Sprintf(format, data...))
+}
+
+func TestEventEmitter(t *testing.T) {
+	te := NewTEvent(t)
+	Event(te, "x")
+	Event(te, "y")
+
+	PrintStats(te)
+	checkMatch(t, fmt.Sprintf("Statistics.*%s", t.Name()), te.output[0])
+	checkMatch(t, "of 2 ", te.output[1])
+	checkMatch(t, "x: 1 \\(50.0+ %", te.output[3])
+	checkMatch(t, "y: 1 \\(50.0+ %", te.output[4])
+}
+
+func checkMatch(t *testing.T, pattern, str string) {
+	matched, err := regexp.MatchString(pattern, str)
+	if err != nil {
+		t.Fatalf("Regex compile failed")
+	}
+	if !matched {
+		t.Fatalf("Pattern <%s> does not match in <%s>", pattern, str)
+	}
+}


### PR DESCRIPTION
This PR implements the proposal of #30. 

I am using interface `rapid.TB` instead of `rapid.T` to introduce a test adapter for checking the `PrintStats()` methods. That reads a little odd, any improvement here are welcome. 

