### PR TITLE
Update 3rd Playground Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ regexp to see what happens when it is generating invalid addresses
 function ([source code](./example_function_test.go),
 [playground](https://go.dev/play/p/tZFU8zv8AUl)) and state machine
 ([source code](./example_statemachine_test.go),
-[playground](https://go.dev/play/p/LRb_Nm1s9T5)) example tests are provided.
+[playground](https://go.dev/play/p/HeSnPeEbuQk)) example tests are provided.
 They both fail. Making them pass is a good way to get first real experience
 of working with rapid.
 


### PR DESCRIPTION
## Update the State Machine Playground Example

I'm getting the following error when attempting to run the [current playground link](https://go.dev/play/p/LRb_Nm1s9T5):

```
go: finding module for package pgregory.net/rapid
go: downloading pgregory.net/rapid v0.6.0
go: found pgregory.net/rapid in pgregory.net/rapid v0.6.0
# play [play.test]
./prog_test.go:85:23: undefined: rapid.Run
```

I'm swapping in [this playground](https://go.dev/play/p/HeSnPeEbuQk) which is giving the intended error???

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x56a75e]

goroutine 1 [running]:
pgregory.net/rapid.Check(0x0, 0xc0000061a0?)
	/tmp/gopath1637942906/pkg/mod/pgregory.net/rapid@v0.6.0/engine.go:92 +0x1e
main.main()
	/tmp/sandbox58985778/prog.go:76 +0x25

Program exited.
```