### PR TITLE
bugfix: ensure no panics when calling t.Name() inside a generator

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -580,6 +580,14 @@ func (t *T) SkipNow() {
 	t.skip("(*T).SkipNow() called")
 }
 
+func (t *T) Name() string {
+	if t.tb != nil {
+		return t.tb.Name()
+	}
+
+	return ""
+}
+
 // Errorf is equivalent to [T.Logf] followed by [T.Fail].
 func (t *T) Errorf(format string, args ...any) {
 	if t.tbLog && t.tb != nil {

--- a/engine_test.go
+++ b/engine_test.go
@@ -7,6 +7,7 @@
 package rapid
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -92,4 +93,17 @@ func BenchmarkCheckOverhead(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		checkTB(b, deadline, f)
 	}
+}
+
+func TestNameInGeneratorStillWorksIfUsingExample(t *testing.T) {
+	g := Custom(func(t *T) string {
+		str := Just("rapid test").Draw(t, "")
+		return fmt.Sprintf("%s-%s", str, t.Name())
+	})
+	t.Run("does not panic when calling t.Name() inside generator called via .Example()", func(t *testing.T) {
+		exmpl := g.Example(0)
+		if exmpl != "rapid test-" {
+			t.Fatalf("expected example %s to contain the rapid test identifier and not panic", exmpl)
+		}
+	})
 }


### PR DESCRIPTION
This is a fairly annoying footgun. While rapid.T is guaranteed to never be nil pretty much, we offer no such guarantees as to the presence of testing.T inside of it. As a result calling APIs present on rapid.T interface can result in panics if invoked via `.Example()` instead of .Draw()

Attached test case would fail prior to this change and illustrates the problem