### PR TITLE
StateMachineActions: Support `func(rapid.TB)` actions

### DIFF
--- a/statemachine.go
+++ b/statemachine.go
@@ -88,9 +88,21 @@ func StateMachineActions(sm StateMachine) map[string]func(*T) {
 	actions := make(map[string]func(*T), n)
 	for i := 0; i < n; i++ {
 		name := t.Method(i).Name
+
+		if name == checkMethodName {
+			continue
+		}
+
 		m, ok := v.Method(i).Interface().(func(*T))
-		if ok && name != checkMethodName {
+		if ok {
 			actions[name] = m
+		}
+
+		m2, ok := v.Method(i).Interface().(func(TB))
+		if ok {
+			actions[name] = func(t *T) {
+				m2(t)
+			}
 		}
 	}
 

--- a/statemachine.go
+++ b/statemachine.go
@@ -72,7 +72,8 @@ type StateMachine interface {
 	// Check is ran after every action and should contain invariant checks.
 	//
 	// All other public methods should have a form ActionName(t *rapid.T)
-	// and are used as possible actions. At least one action has to be specified.
+	// or ActionName(t rapid.TB) and are used as possible actions.
+	// At least one action has to be specified.
 	Check(*T)
 }
 

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -6,7 +6,10 @@
 
 package rapid
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 // https://github.com/leanovate/gopter/blob/master/commands/example_circularqueue_test.go
 var gopterBug = false
@@ -231,6 +234,35 @@ func TestStateMachine_DiscardGarbage(t *testing.T) {
 		"AddA", 0,
 		"AddA", 0,
 	)
+}
+
+type stateMachineTest struct {
+	run []string
+}
+
+func (sm *stateMachineTest) ActionA(t *T) {
+	sm.run = append(sm.run, "actionA")
+}
+func (sm *stateMachineTest) ActionB(t TB) { sm.run = append(sm.run, "actionB") }
+func (sm *stateMachineTest) ActionC(t *T) { sm.run = append(sm.run, "actionC") }
+func (sm *stateMachineTest) Check(*T)     {}
+
+func TestStateMachineActions(t *testing.T) {
+	Check(t, func(t *T) {
+		sm := &stateMachineTest{}
+		actions := StateMachineActions(sm)
+		actions["ActionA"](t)
+		actions["ActionB"](t)
+		actions["ActionC"](t)
+
+		if want := []string{
+			"actionA",
+			"actionB",
+			"actionC",
+		}; !reflect.DeepEqual(want, sm.run) {
+			t.Fatalf("expected state %v, got %v", want, sm.run)
+		}
+	})
 }
 
 func BenchmarkCheckQueue(b *testing.B) {

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -271,12 +271,12 @@ func TestStateMachineActions(t *testing.T) {
 		}
 
 		var want []string
-		for i := 0; i < Int().Draw(t, "ActionT acount"); i++ {
+		for i := 0; i < Int().Draw(t, "ActionT count"); i++ {
 			actionT(t)
 			want = append(want, "ActionT")
 		}
 
-		for i := 0; i < Int().Draw(t, "ActionTB acount"); i++ {
+		for i := 0; i < Int().Draw(t, "ActionTB count"); i++ {
 			actionTB(t)
 			want = append(want, "ActionTB")
 		}


### PR DESCRIPTION
This allows reuse actions from normal tests that use `testing.TB`.

This is helpful for tests where there may be very specific test scenarios where some logic is abstracted into a common action.