### PR TITLE
`Make[T]()`: add support for field and type overrides

### DIFF
--- a/make_test.go
+++ b/make_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Gregory Petrosyan <gregory.petrosyan@gmail.com>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package rapid_test
+
+import (
+	"reflect"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+type PrivateFields struct {
+	private bool
+}
+
+func TestMake(t *testing.T) {
+	// Private fields are ignored (and don't panic).
+	rapid.Make[PrivateFields]().Example()
+}
+
+func TestMakeCustom(t *testing.T) {
+	ex := rapid.MakeCustom[PrivateFields](rapid.MakeConfig{
+		Types: map[reflect.Type]*rapid.Generator[any]{
+			reflect.TypeOf(PrivateFields{}): rapid.Just(PrivateFields{private: true}).AsAny(),
+		},
+	}).Example()
+
+	if !ex.private {
+		t.Errorf(".private should be true. got: %#v", ex)
+	}
+}


### PR DESCRIPTION
👋 I was utilizing rapid for a test involving Kubernetes objects (`corev1.Pod`) and wanted to leverage `Make` instead of hand writing all the generation. I was transitioning the tests away from go-fuzz which provides the abilities to skip various fields and override "fuzzing" of others. This PR extends rapid to support a similar feature set.

I'm already using this change in my fork and it works quite well. I'm not overjoyed with the API though but it does get the job done. If you have any suggestions, I'm all ears.