### PR TITLE
ci: Test with Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: CI
     strategy:
       matrix:
-        go: ['1.21', '1.22', '1.23']
+        go: ['1.21', '1.22', '1.23', '1.24']
         os: ['ubuntu-latest', 'windows-latest', 'macOS-latest']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Go 1.24 was released last week.
Test against Go 1.24 in CI as well.

(Per Go support policy, 1.21 and 1.22 are no longer supported,
but I've left them around as rapid may still want to support them.)
