### PR TITLE
feat: Add T.Cleanup

### DIFF
--- a/combinators_external_test.go
+++ b/combinators_external_test.go
@@ -95,6 +95,28 @@ func TestCustomContext(t *testing.T) {
 	})
 }
 
+func TestCustomCleanup(t *testing.T) {
+	t.Parallel()
+
+	var open bool
+	gen := Custom(func(t *T) int {
+		t.Cleanup(func() { open = false })
+		return Int().Draw(t, "")
+	})
+
+	// Cleanup functions registered during a Custom generator
+	// are run after generation, not after the Check.
+	Check(t, func(t *T) {
+		open = true
+		_ = gen.Draw(t, "value")
+
+		// Cleanup must run after each run of the custom generator.
+		if open {
+			t.Fatalf("cleanup must be run")
+		}
+	})
+}
+
 func TestFilter(t *testing.T) {
 	t.Parallel()
 

--- a/engine.go
+++ b/engine.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -506,6 +507,8 @@ type T struct {
 
 	ctx       context.Context
 	cancelCtx context.CancelFunc
+	cleanups  []func()
+	cleaning  atomic.Bool
 
 	tbLog    bool
 	rawLog   *log.Logger
@@ -545,14 +548,24 @@ func (t *T) shouldLog() bool {
 	return t.rawLog != nil || t.tbLog
 }
 
-// Context returns a context.Context associated with the test.
-// It is valid only for the duration of the rapid check.
+// Context returns a context.Context associated with the property check.
+// It is valid only for the duration of the check,
+// and is canceled shortly before Cleanup functions are run.
 func (t *T) Context() context.Context {
 	// Fast path: no need to lock if the context is already set.
 	t.mu.RLock()
 	ctx := t.ctx
 	t.mu.RUnlock()
 	if ctx != nil {
+		return ctx
+	}
+
+	// If we're in the middle of cleaning up
+	// and the context has already been canceled and cleared,
+	// don't create a new one. Return a canceled context instead.
+	if t.cleaning.Load() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
 		return ctx
 	}
 
@@ -582,16 +595,63 @@ func (t *T) Context() context.Context {
 	return ctx
 }
 
-// cleanup runs any cleanup tasks associated with the property check.
-// It is safe to call multiple times.
-func (t *T) cleanup() {
+// Cleanup registers a function to be called
+// when this property check is over.
+// Use it to clean up any resources acquired during the check.
+//
+// Cleanup functions are called in last-in, first-out order.
+//
+// Note that the context returned by [T.Context] is canceled
+// by the time Cleanup functions are run.
+func (t *T) Cleanup(f func()) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	t.cleanups = append(t.cleanups, f)
+}
+
+// cleanup runs any cleanup tasks associated with the property check.
+// It is safe to call multiple times.
+func (t *T) cleanup() {
+	t.cleaning.Store(true)
+	defer t.cleaning.Store(false)
+
+	// If a cleanup function panics,
+	// we still want to run the remaining cleanup functions.
+	defer func() {
+		t.mu.Lock()
+		recurse := len(t.cleanups) > 0
+		t.mu.Unlock()
+
+		if recurse {
+			t.cleanup()
+		}
+	}()
+
+	// Context must be closed before t.Cleanup functions are run.
+	t.mu.Lock()
 	if t.cancelCtx != nil {
 		t.cancelCtx()
 		t.cancelCtx = nil
 		t.ctx = nil
+	}
+	t.mu.Unlock()
+
+	for {
+		var cleanup func()
+		t.mu.Lock()
+		if len(t.cleanups) > 0 {
+			last := len(t.cleanups) - 1
+			cleanup = t.cleanups[last]
+			t.cleanups = t.cleanups[:last]
+		}
+		t.mu.Unlock()
+
+		if cleanup == nil {
+			break
+		}
+
+		cleanup()
 	}
 }
 

--- a/engine_fuzz_test.go
+++ b/engine_fuzz_test.go
@@ -92,3 +92,20 @@ func FuzzContext(f *testing.F) {
 		}
 	}
 }
+
+func FuzzCleanup(f *testing.F) {
+	var state []bool
+	f.Fuzz(MakeFuzz(func(t *T) {
+		idx := len(state)
+		state = append(state, false)
+		t.Cleanup(func() {
+			state[idx] = true
+		})
+	}))
+
+	for _, ok := range state {
+		if !ok {
+			f.Fatalf("cleanup must be called")
+		}
+	}
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -46,7 +46,7 @@ func TestExampleHelper(t *testing.T) {
 	g.Example(0)
 }
 
-func TestExampleContext(t *testing.T) {
+func TestCustomExampleContext(t *testing.T) {
 	type key struct{}
 
 	g := Custom(func(t *T) context.Context {
@@ -65,5 +65,19 @@ func TestExampleContext(t *testing.T) {
 
 	if _, ok := ctx.Value(key{}).(int); !ok {
 		t.Fatalf("context must have a value")
+	}
+}
+
+func TestCustomExampleCleanup(t *testing.T) {
+	var state bool
+	g := Custom(func(t *T) int {
+		t.Cleanup(func() { state = false })
+		return Int().Draw(t, "x")
+	})
+
+	state = true
+	_ = g.Example(0)
+	if state {
+		t.Fatalf("cleanup must be called")
 	}
 }


### PR DESCRIPTION
Adds a new T.Cleanup method to register cleanup functions.
These will run after each iteration of a Check or custom generator.

The implementation of how cleanup functions are tracked and run
is borrowed heavily from testing.T's own implementation.
Namely:

- [T.Cleanup puts functions in a slice](https://cs.opensource.google/go/go/+/refs/tags/go1.24.0:src/testing/testing.go;l=1214-1216)
- [cleanups are run in reverse order](https://cs.opensource.google/go/go/+/refs/tags/go1.24.0:src/testing/testing.go;l=1433-1446) popping functions from the slice one by one
- [panics are not allowed to interrupt cleanup](https://cs.opensource.google/go/go/+/refs/tags/go1.24.0:src/testing/testing.go;l=1420-1427)

As with `testing.T`, cleanup runs after the context is canceled.
Because Rapid's Context is lazily initialized,
it needs an additional check to avoid providing a valid context
during cleanup.

Resolves #62
